### PR TITLE
fix(action): refresh dependencies and release metadata

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
       schedule:
           interval: weekly
       reviewers:
-          - koconder
+          - vincentkoc
     - package-ecosystem: pip
       directory: /
       schedule:
           interval: weekly
       reviewers:
-          - koconder
+          - vincentkoc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,13 +5,14 @@ on:
         types: [opened, synchronize, edited]
     push:
         branches:
-            - master
+            - main
 
 concurrency:
     group: environment-${{ github.ref }}
     cancel-in-progress: true
 
 permissions:
+    contents: read
     issues: write
     pull-requests: write
 
@@ -45,6 +46,7 @@ jobs:
               uses: ./ # Use an action in the same repository
               with:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PR_TITLE: ${{ github.event.pull_request.title || github.event.head_commit.message }}
                   TIMEZONE: Australia/Sydney
                   RESTRICTED_TIMES: >-
                       {

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim
 
-LABEL version="1.0.0"
-LABEL repository="https://github.com/koconder/no-out-of-hours-merge"
+LABEL version="1.1.0"
+LABEL repository="https://github.com/vincentkoc/no-out-of-hours-merge"
 LABEL maintainer="Vincent Koc"
 ENV DOCKER_BUILDKIT=1
 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,23 @@ on:
       - reopened
 
 jobs:
-  no_weekend_merge:
+  no_out_of_hours_merge:
     name: Out of Hours Check ⏰
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
+        uses: actions/checkout@v6
 
       - name: Block merge during specified times
-        env:
+        uses: vincentkoc/no-out-of-hours-merge@v1
+        with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
           TIMEZONE: "Australia/Sydney"
           RESTRICTED_TIMES: >
             {
@@ -71,18 +72,18 @@ jobs:
               }
             }
           CUSTOM_MESSAGE: "⚠️ **PR merging is not allowed outside business hours. Let's not be a cowboy!** ⚠️"
-        run: no-weekend-merge
 
 ```
 
 ## Configuration
 
-You can configure the action using the following environment variables:
+You can configure the action using the following inputs:
 
 - `GITHUB_TOKEN`: Required to post a message back to the PR.
+- `PR_TITLE`: Pull request title used to allow `hotfix:` bypasses.
 - `CUSTOM_MESSAGE`: The custom message that will be posted as a comment on the pull request if merging is not allowed (default: `"⚠️ PR merging is not allowed outside business hours. ⚠️"`).
-- `CHECK_EXISTING_COMMENT`: Dont post the same message twice (default: enabled)
-- `TIMEZONE`: The timezone used for checking the current time (default: `"Australia/Sydney"`).
+- `CHECK_EXISTING_COMMENT`: Don't post the same message twice (default: enabled).
+- `TIMEZONE`: The timezone used for checking the current time (default: `"Europe/London"`).
 - `RESTRICTED_TIMES`: A JSON string containing the restricted times for each day of the week (default: the provided example in the Usage section).
 
 ## License

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyGithub==2.9.1
-pytz==2023.3.post1
-python-dateutil>=2.8.0
+pytz==2026.1.post1
+python-dateutil>=2.9.0.post0
 holidays>=0.83
-regex>=2023.3.22
+regex>=2026.1.15

--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,21 @@ with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setup(
-    name="no-weekend-merge",
-    version="0.1.0",
+    name="no-out-of-hours-merge",
+    version="1.1.0",
     author_email="vincentkoc@ieee.org",
     description="A GitHub action to restrict PR merges outside "
     + "specified hours, days, and holidays.",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/koconder/no-out-of-hours-merge",
+    url="https://github.com/vincentkoc/no-out-of-hours-merge",
     packages=find_packages(where="src"),
+    py_modules=["main"],
     package_dir={"": "src"},
     entry_points={
         "console_scripts": [
-            "no-out-of-hours-merge = no-out-of-hours-merge:main",
+            "no-out-of-hours-merge = main:main",
+            "no-weekend-merge = main:main",
         ],
     },
     classifiers=[
@@ -25,15 +27,17 @@ setup(
         "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
-        "github3.py>=2.0.0",
-        "python-dateutil>=2.8.1",
-        "pytz>=2021.1",
-        "holidays>=0.11.3",
-        "regex>=2023.3.22",
+        "PyGithub>=2.9.1",
+        "python-dateutil>=2.9.0.post0",
+        "pytz>=2026.1.post1",
+        "holidays>=0.83",
+        "regex>=2026.1.15",
     ],
 )

--- a/src/main.py
+++ b/src/main.py
@@ -3,13 +3,26 @@ import json
 import os
 import re
 import sys
-from typing import Any, Dict
+from functools import lru_cache
+from typing import Any, Dict, Optional
 
 import holidays
 import pytz
 from dateutil import parser
 from dateutil.rrule import FR, MO, SA, SU, TH, TU, WE
 from github import Github
+
+DAY_MAP = {
+    "mon": MO,
+    "tue": TU,
+    "wed": WE,
+    "thu": TH,
+    "fri": FR,
+    "sat": SA,
+    "sun": SU,
+}
+VALID_DAYS = set(DAY_MAP)
+PULL_REQUEST_REF_PATTERN = re.compile(r"refs/pull/(\d+)/merge")
 
 
 def post_comment_on_pr(
@@ -38,24 +51,32 @@ def validate_timezone(timezone: str) -> None:
         )
 
 
+@lru_cache(maxsize=32)
+def get_country_holidays(country: str, subdiv: Optional[str]):
+    return holidays.country_holidays(country=country, subdiv=subdiv)
+
+
 def is_holiday(now, holidays_config):
     if not holidays_config:
         return False
 
-    country_holidays = holidays.country_holidays(
+    country_holidays = get_country_holidays(
         country=holidays_config["country"], subdiv=holidays_config.get("state", None)
     )
 
     return now.date() in country_holidays
 
 
+def is_inside_interval(hour, intervals):
+    return any(start <= hour < end for start, end in intervals)
+
+
 def validate_restricted_times(restricted_times: Dict[str, Any]) -> None:
     if "weekly" not in restricted_times:
         raise ValueError("Missing 'weekly' key in restricted_times dictionary.")
 
-    valid_days = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"}
     for rule in restricted_times["weekly"]:
-        if not set(rule["days"]).issubset(valid_days):
+        if not set(rule["days"]).issubset(VALID_DAYS):
             raise ValueError(
                 "Invalid day keys in the restricted_times dictionary. Use "
                 + "'mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'."
@@ -72,11 +93,11 @@ def validate_restricted_times(restricted_times: Dict[str, Any]) -> None:
                     f"Invalid interval '{interval}' for '{rule['days']}'"
                     + " in restricted_times. It should be a tuple with two numbers."
                 )
-            if interval[1] <= interval[0]:
+            if interval[0] < 0 or interval[1] > 24 or interval[1] <= interval[0]:
                 raise ValueError(
                     f"Invalid interval '{interval}' for '{rule['days']}'"
-                    + " in restricted_times. The second number should"
-                    + " be greater than the first."
+                    + " in restricted_times. Intervals must be within 0-24"
+                    + " and the second number should be greater than the first."
                 )
 
 
@@ -90,45 +111,29 @@ def is_restricted_time(timezone, restricted_times, now=None):
     if now is None:
         now = datetime.datetime.now(tz)
     now = now.astimezone(tz)
+    current_hour = now.hour + now.minute / 60
 
     for rule in restricted_times["weekly"]:
-        day_map = {
-            "mon": MO,
-            "tue": TU,
-            "wed": WE,
-            "thu": TH,
-            "fri": FR,
-            "sat": SA,
-            "sun": SU,
-        }
-        mapped_days = [day_map[d] for d in rule["days"]]
-        if now.weekday() in [d.weekday for d in mapped_days] and any(
-            start <= now.hour + now.minute / 60 < end
-            for start, end in rule["intervals"]
+        mapped_days = [DAY_MAP[d] for d in rule["days"]]
+        if now.weekday() in [d.weekday for d in mapped_days] and is_inside_interval(
+            current_hour, rule["intervals"]
         ):
             return True
 
-    for rule in restricted_times["dates"]:
+    for rule in restricted_times.get("dates", []):
         date = parser.parse(rule["date"]).date()
-        if now.date() == date and any(
-            start <= now.hour + now.minute / 60 < end
-            for start, end in rule["intervals"]
-        ):
+        if now.date() == date and is_inside_interval(current_hour, rule["intervals"]):
             return True
 
     holiday_intervals = restricted_times.get("holidays", {}).get("intervals", [])
     return bool(
         is_holiday(now, restricted_times.get("holidays"))
-        and any(
-            start <= now.hour + now.minute / 60 < end
-            for start, end in holiday_intervals
-        )
+        and is_inside_interval(current_hour, holiday_intervals)
     )
 
 
 def parse_pull_request_id(github_ref):
-    pattern = r"refs/pull/(\d+)/merge"
-    if match := re.search(pattern, github_ref):
+    if match := PULL_REQUEST_REF_PATTERN.search(github_ref):
         return int(match[1])
     else:
         raise ValueError(f"Invalid GitHub ref: {github_ref}")
@@ -144,13 +149,13 @@ def main():
             }
         ],
         "dates": [{"date": "2023-12-25", "intervals": [[0, 24]]}],
-        "holidays": {"country": "AU", "state": "NSW", "intervals": [[0, 24]]},
+        "holidays": {"country": "GB", "state": "UK", "intervals": [[0, 24]]},
     }
 
     # Get the inputs from the environment
     github_token = os.environ["INPUT_GITHUB_TOKEN"]
     pr_title = os.environ["INPUT_PR_TITLE"]
-    timezone = os.environ.get("INPUT_TIMEZONE", "Australia/Sydney")
+    timezone = os.environ.get("INPUT_TIMEZONE", "Europe/London")
     restricted_times_json = os.environ.get(
         "INPUT_RESTRICTED_TIMES", json.dumps(restricted_times_default)
     )

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -4,6 +4,7 @@ import unittest
 from main import (  # isort:skip
     is_holiday,
     is_restricted_time,
+    parse_pull_request_id,
     validate_custom_message,
     validate_restricted_times,
     validate_timezone,
@@ -56,6 +57,7 @@ class TestMain(unittest.TestCase):
                 }
             ]
         }
+        invalid_interval = {"weekly": [{"days": ["mon"], "intervals": [[-1, 25]]}]}
         self.assertIsNone(
             validate_restricted_times(valid_restricted_times),
             "Valid restricted times should pass validation.",
@@ -64,6 +66,10 @@ class TestMain(unittest.TestCase):
             ValueError, msg="Invalid restricted times should raise ValueError."
         ):
             validate_restricted_times(invalid_restricted_times)
+        with self.assertRaises(
+            ValueError, msg="Out-of-range intervals should raise ValueError."
+        ):
+            validate_restricted_times(invalid_interval)
 
     def test_is_holiday(self):
         fixed_datetime = datetime.datetime(
@@ -112,6 +118,24 @@ class TestMain(unittest.TestCase):
         with freeze_time(fixed_datetime):
             result = is_restricted_time(timezone, restricted_times, now=fixed_datetime)
             self.assertTrue(result, "This time should be restricted.")
+
+    def test_is_restricted_time_without_dates(self):
+        restricted_times = {
+            "weekly": [{"days": ["mon"], "intervals": [[9, 10]]}],
+            "holidays": {},
+        }
+        fixed_datetime = datetime.datetime(2023, 1, 3, 12, 0, tzinfo=pytz.UTC)
+
+        result = is_restricted_time(
+            "Europe/London", restricted_times, now=fixed_datetime
+        )
+
+        self.assertFalse(result, "Missing dates should be treated as no date rules.")
+
+    def test_parse_pull_request_id(self):
+        self.assertEqual(parse_pull_request_id("refs/pull/123/merge"), 123)
+        with self.assertRaises(ValueError):
+            parse_pull_request_id("refs/heads/main")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- applies the remaining dependency updates from Dependabot PRs #20, #24, and #25
- aligns package metadata, console scripts, Docker labels, Dependabot reviewers, docs, and CI defaults with the current repo
- hardens restricted-time checks with cached holiday lookups, bounded intervals, optional dates handling, and PR ref parsing tests

## Validation
- .venv/bin/python -m black src/ setup.py
- .venv/bin/python -m flake8 src/ --count
- .venv/bin/python -m unittest discover -t ./src/ -s ./src/tests
- .venv/bin/pip install -e .
- .venv/bin/no-out-of-hours-merge smoke test
- .venv/bin/no-weekend-merge smoke test
- git diff --check

Supersedes #20, #24, #25.